### PR TITLE
Resolve data hang between CAN read and TCP write threads

### DIFF
--- a/client/client.cpp
+++ b/client/client.cpp
@@ -388,7 +388,9 @@ int read_frame(int soc, struct can_frame* frame, struct timeval* tv)
 {
     int bytes;
 
-    bytes = read(soc, frame, sizeof(*frame));
+    //bytes = read(soc, frame, sizeof(*frame));
+    bytes = recv(soc, frame, sizeof(*frame), MSG_DONTWAIT);
+    
 #if !CAN_FORWARDER_MODE
     ioctl(soc, SIOCGSTAMP, tv);
 #endif

--- a/client/client.cpp
+++ b/client/client.cpp
@@ -472,6 +472,7 @@ void* read_poll_can(void* args)
                 if (count > (BUF_SZ - frame_sz))
                 {
                     //full buffer, drop data and start over. TODO: ring buffer, print/debug
+                    fprintf(stderr, "Intermediate TCP-CAN buffer overflow");
                     bufpnt = read_buf_can;
                     count = 0;
                 }

--- a/client/client.cpp
+++ b/client/client.cpp
@@ -433,9 +433,8 @@ void* read_poll_can(void* args)
 #endif
         if (num_bytes_can < 0)
         {
-            // Return value of -1 happens when there is a timeout, we simply keep looping, as we want do not want to block while
-            // reading the CAN-Bus, as then we would never be able to shut down the threads if there was no activity
-            // on the bus
+            // Return value of -1 happens when there is a timeout, we simply keep looping, as we want do not want to block,
+            // as then we would never be able to shut down the threads if there was no activity on the bus
             // Negative return value other than -1 should not occur according to documentation.
         }
         else if (num_bytes_can == 0)
@@ -670,9 +669,8 @@ void* write_poll(void* args)
         int num_bytes_tcp = read(socks->tcp_sock, write_buf, BUF_SZ);
         if (num_bytes_tcp < 0)
         {
-            // Return value of -1 happens when there is a timeout, we simply keep looping, as we want do not want to block while
-            // writing to the CAN-Bus, as then we would never be able to shut down the threads if there was no activity
-            // on the bus
+            // Return value of -1 happens when there is a timeout, we simply keep looping, as we want do not want to block,
+            // as then we would never be able to shut down the threads if there was no new data over TCP
             // Negative return value other than -1 should not occur according to documentation.
             continue;
         }


### PR DESCRIPTION
This was fixed by not blocking when reading the CAN socket if there was data that still had not been sent to the `read_poll_tcp` thread