### PR TITLE
Build wheels for more versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,10 +5,11 @@ on: [push, pull_request]
 jobs:
   armv7l:
     name: Build armv7l wheels
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
     strategy:
       matrix:
-        docker_images: ['balenalib/armv7hf-debian:stretch', 'balenalib/armv7hf-debian:buster', 'balenalib/armv7hf-debian:bullseye']
+        docker_images: ['balenalib/armv7hf-debian:buster', 'balenalib/armv7hf-debian:bullseye', 'balenalib/armv7hf-debian:bookworm']
     steps:
     - uses: actions/checkout@v3
     - name: Build ${{ matrix.docker_images }} wheel
@@ -24,10 +25,11 @@ jobs:
         path: dist
   amd64:
     name: Build amd64 wheels
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
     strategy:
       matrix:
-        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
@@ -54,7 +56,8 @@ jobs:
         path: dist
   sdist:
     name: Build sdist
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.10
@@ -73,7 +76,8 @@ jobs:
   release:
     needs: [armv7l, amd64, sdist]
     name: Release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
     steps:
     - name: Set up Python 3.10
       uses: actions/setup-python@v4
@@ -100,5 +104,6 @@ jobs:
       with:
         files: socketsocketcan/*
         draft: true
+        fail_on_unmatched_files: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Dockerfile.armv7l
+++ b/Dockerfile.armv7l
@@ -9,6 +9,7 @@ RUN [ "cross-build-start" ]
 RUN apt-get -y update
 RUN apt-get -y install apt-utils
 RUN apt-get -y install build-essential python3-dev python3-pip
+RUN rm /usr/lib/python3.*/EXTERNALLY-MANAGED || true
 RUN python3 -m pip install --extra-index-url=https://www.piwheels.org/simple -U pip setuptools wheel pybind11
 
 # Build the wheel.


### PR DESCRIPTION
Drop support for x86 Python 3.5, 3.6 and 3.7 and armv7l stretch (3.5)

Also updated the jobs to run on Ubuntu 24.04