### PR TITLE
Build the x86 wheels on Ubuntu 20.04, so they are compatible with old…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
         if-no-files-found: error
   amd64:
     name: Build amd64 wheels
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 5
     strategy:
       matrix:


### PR DESCRIPTION
…er versions of Ubuntu than 24.04